### PR TITLE
Remove unnecessary tasks from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,3 @@ dev-deps:
 
 clean:
 	go clean
-	rm -f nat-builder
-
-dist-clean:
-	rm -rf pkg src bin
-
-ci-deps:


### PR DESCRIPTION
task `ci-deps` is empty so it can be discarded, also dist-clean is not necessary anymore as we are using go install instead of go build to compile the service.
